### PR TITLE
Update the combinations calculation to only use the first number

### DIFF
--- a/services.html
+++ b/services.html
@@ -90,13 +90,12 @@
 
         document.getElementById("combinationsButton").addEventListener("click", function() {
             var number1 = parseInt(document.getElementById("number1").value);
-            var number2 = parseInt(document.getElementById("number2").value);
 
             function factorial(n) {
                 return n ? n * factorial(n - 1) : 1;
             }
 
-            var combinations = factorial(number1) / (factorial(number2) * factorial(number1 - number2));
+            var combinations = factorial(number1) / factorial(number1 - 1);
             document.getElementById("combinationsResult").innerText = "Combinations: " + combinations;
         });
     </script>


### PR DESCRIPTION
Fixes #60

Update the combinations calculation in `services.html` to only use the first number.

* Remove the use of `number2` in the combinations calculation.
* Modify the combinations formula to `factorial(number1) / factorial(number1 - 1)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snidman/snidman.github.io/pull/61?shareId=0b33e1e3-6593-4fbc-ae8e-cfdf29293130).