### PR TITLE
Change background color to light blue

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -164,3 +164,8 @@ textarea {
     border: 1px solid #ddd;
     border-radius: 5px;
 }
+
+/* P9bb2 */
+body {
+    background-color: lightblue;
+}


### PR DESCRIPTION
Fixes #62

Add a CSS rule to set the background color of the `body` element to light blue.

* Add a new rule in `styles.css` to set the background color of the `body` element to light blue.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snidman/snidman.github.io/pull/63?shareId=5947856d-25b3-4333-81cc-b2efaa907c06).