### PR TITLE
Remove background color from all pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -164,8 +164,3 @@ textarea {
     border: 1px solid #ddd;
     border-radius: 5px;
 }
-
-/* P9bb2 */
-body {
-    background-color: lightblue;
-}


### PR DESCRIPTION
Fixes #64

Remove the light blue background color from all pages.

* Remove the `background-color: lightblue;` property from the `body` element in `styles.css`
* Delete the `body` element block from `styles.css`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snidman/snidman.github.io/pull/65?shareId=ec497333-d83d-4da7-a695-1480348afbbc).