### PR TITLE
Add light blue background to all pages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -164,3 +164,7 @@ textarea {
     border: 1px solid #ddd;
     border-radius: 5px;
 }
+
+body {
+    background-color: lightblue;
+}


### PR DESCRIPTION
Fixes #68

Add a light blue background color to all pages.

* Modify `styles.css` to include a `body` selector with `background-color: lightblue;` to set the background color of all pages to light blue.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snidman/snidman.github.io/pull/69?shareId=bf61ca1e-a7b2-45ce-8158-b81a923bd47b).