### PR TITLE
Make background of screens blue

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -165,3 +165,7 @@ textarea {
     border-radius: 5px;
 }
 
+/* Pd5f7 */
+body {
+    background-color: blue;
+}


### PR DESCRIPTION
Fixes #72

Set the background color of the `body` element to blue in `styles.css`.

* Add a CSS rule to set the background color of the `body` element to blue.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snidman/snidman.github.io/pull/73?shareId=e86828d8-7f16-465f-8b72-ef798dea914e).