### PR TITLE
Remove background color from screens

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -10,7 +10,6 @@ div {
     flex-direction: column;
     align-items: flex-start;
     padding: 10px;
-    background-color: #f8f8f8;
     border: 1px solid #ddd;
     width: 200px;
     position: fixed;
@@ -42,7 +41,6 @@ div {
 }
 
 .menu a:hover {
-    background-color: #ddd;
 }
 
 .submenu {
@@ -60,7 +58,6 @@ div {
 h1 {
     margin: 0;
     padding: 10px;
-    background-color: #f8f8f8;
     border-bottom: 1px solid #ddd;
     width: 100%;
     text-align: center;
@@ -167,5 +164,4 @@ textarea {
 
 /* Pd5f7 */
 body {
-    background-color: blue;
 }


### PR DESCRIPTION
Fixes #74

Remove background colors from various elements in `styles.css`.

* Remove the `background-color` property from the `body` selector.
* Remove the `background-color` property from the `menu-container` class.
* Remove the `background-color` property from the `h1` element.
* Remove the `background-color` property from the `menu a:hover` selector.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/snidman/snidman.github.io/pull/75?shareId=3392a17f-f543-4bd4-b740-7f8165d995c6).